### PR TITLE
fix(client-credentials): harden token refresh and cache tonic metadata

### DIFF
--- a/crates/middle/src/authorizers/bearer_token.rs
+++ b/crates/middle/src/authorizers/bearer_token.rs
@@ -64,10 +64,8 @@ impl Authorizer for BearerTokenAuthorizer {
     #[cfg(feature = "tonic")]
     fn authorization_header_tonic(
         &self,
-    ) -> std::result::Result<
-        tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
-        tonic::Status,
-    > {
+    ) -> std::result::Result<tonic::metadata::MetadataValue<tonic::metadata::Ascii>, tonic::Status>
+    {
         Ok(self.authorization_metadata.clone())
     }
 }

--- a/crates/middle/src/authorizers/bearer_token.rs
+++ b/crates/middle/src/authorizers/bearer_token.rs
@@ -19,6 +19,11 @@ use crate::error::{Error, Result};
 pub struct BearerTokenAuthorizer {
     #[redact]
     authorization_header: Arc<HeaderValue>,
+    // Pre-computed tonic representation, cloned cheaply on the interceptor hot
+    // path instead of re-parsing the header on every request.
+    #[cfg(feature = "tonic")]
+    #[redact]
+    authorization_metadata: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
 }
 
 impl BearerTokenAuthorizer {
@@ -29,12 +34,24 @@ impl BearerTokenAuthorizer {
     /// Fails if "Bearer {token}" is not a valid ASCII string.
     pub fn new(token: &str) -> Result<Self> {
         require_ascii(token)?;
-        let mut authentication_header = HeaderValue::from_str(&format!("Bearer {token}"))
-            .map_err(|_e| Error::InvalidHeaderValue)?;
+        let bearer = format!("Bearer {token}");
+        let mut authentication_header =
+            HeaderValue::from_str(&bearer).map_err(|_e| Error::InvalidHeaderValue)?;
         authentication_header.set_sensitive(true);
+
+        #[cfg(feature = "tonic")]
+        let authorization_metadata = {
+            use std::str::FromStr;
+            let mut metadata = tonic::metadata::MetadataValue::from_str(&bearer)
+                .map_err(|_e| Error::InvalidHeaderValue)?;
+            metadata.set_sensitive(true);
+            metadata
+        };
 
         Ok(Self {
             authorization_header: Arc::new(authentication_header),
+            #[cfg(feature = "tonic")]
+            authorization_metadata,
         })
     }
 }
@@ -42,6 +59,16 @@ impl BearerTokenAuthorizer {
 impl Authorizer for BearerTokenAuthorizer {
     fn authorization_header(&self) -> Result<Arc<HeaderValue>> {
         Ok(self.authorization_header.clone())
+    }
+
+    #[cfg(feature = "tonic")]
+    fn authorization_header_tonic(
+        &self,
+    ) -> std::result::Result<
+        tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+        tonic::Status,
+    > {
+        Ok(self.authorization_metadata.clone())
     }
 }
 

--- a/crates/middle/src/authorizers/client_credentials.rs
+++ b/crates/middle/src/authorizers/client_credentials.rs
@@ -19,10 +19,10 @@ use oauth2::{
         BasicTokenResponse,
     },
 };
+use tracing::Instrument;
 
 use super::Authorizer;
 use crate::error::Error;
-use tracing::Instrument;
 
 /// Minimum delay the refresh loop waits between refresh attempts, even when the
 /// token is already within (or past) its refresh tolerance. Prevents hammering
@@ -848,8 +848,7 @@ impl<
                 // token. This prevents a transient IdP outage during the refresh
                 // window (which fires `tolerance` before expiry) from discarding an
                 // otherwise-valid token.
-                let keep_existing =
-                    matches!(&*state_write_guard, Ok(token) if !token.is_expired());
+                let keep_existing = matches!(&*state_write_guard, Ok(token) if !token.is_expired());
                 if !keep_existing {
                     *state_write_guard = Err(e.clone());
                 }
@@ -901,10 +900,8 @@ impl<
     #[cfg(feature = "tonic")]
     fn authorization_header_tonic(
         &self,
-    ) -> std::result::Result<
-        tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
-        tonic::Status,
-    > {
+    ) -> std::result::Result<tonic::metadata::MetadataValue<tonic::metadata::Ascii>, tonic::Status>
+    {
         // Clone the pre-computed metadata value (cheap, `Bytes`-backed) instead of
         // re-parsing the header string on every request.
         let state_read_guard = self.inner.token.read().expect("Non-poisoned lock");

--- a/crates/middle/src/authorizers/client_credentials.rs
+++ b/crates/middle/src/authorizers/client_credentials.rs
@@ -22,6 +22,12 @@ use oauth2::{
 
 use super::Authorizer;
 use crate::error::Error;
+use tracing::Instrument;
+
+/// Minimum delay the refresh loop waits between refresh attempts, even when the
+/// token is already within (or past) its refresh tolerance. Prevents hammering
+/// the identity provider for very short-lived tokens or during an outage.
+const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 impl<TE: ErrorResponse> From<RequestTokenError<oauth2::HttpClientError<reqwest::Error>, TE>>
     for Error
@@ -249,23 +255,47 @@ struct Inner<
 }
 
 #[derive(veil::Redact, Clone)]
+// `token` / `token_expiry` intentionally share the struct name for clarity.
+#[allow(clippy::struct_field_names)]
 struct Token {
     #[redact]
     token: Arc<HeaderValue>,
+    // Pre-computed tonic representation, cloned cheaply on the interceptor hot
+    // path instead of re-parsing the header on every request.
+    #[cfg(feature = "tonic")]
+    #[redact]
+    metadata: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
     token_expiry: Option<Instant>,
 }
 
 impl Token {
     fn try_from_tr<TR: TokenResponse>(tr: &TR) -> Result<Self, Error> {
-        HeaderValue::from_str(&format!("Bearer {}", tr.access_token().secret()))
-            .map_err(|_| Error::InvalidHeaderValue)
-            .map(|mut token| {
-                token.set_sensitive(true);
-                Token {
-                    token: Arc::new(token),
-                    token_expiry: tr.expires_in().map(|e| Instant::now() + e),
-                }
-            })
+        let bearer = format!("Bearer {}", tr.access_token().secret());
+        let mut token = HeaderValue::from_str(&bearer).map_err(|_| Error::InvalidHeaderValue)?;
+        token.set_sensitive(true);
+
+        #[cfg(feature = "tonic")]
+        let metadata = {
+            use std::str::FromStr;
+            let mut metadata = tonic::metadata::MetadataValue::from_str(&bearer)
+                .map_err(|_| Error::InvalidHeaderValue)?;
+            metadata.set_sensitive(true);
+            metadata
+        };
+
+        Ok(Token {
+            token: Arc::new(token),
+            #[cfg(feature = "tonic")]
+            metadata,
+            token_expiry: tr.expires_in().map(|e| Instant::now() + e),
+        })
+    }
+
+    /// Returns `true` if the token has a known expiry that has already passed.
+    /// Tokens without an expiry are treated as never expiring.
+    fn is_expired(&self) -> bool {
+        self.token_expiry
+            .is_some_and(|expiry| Instant::now() >= expiry)
     }
 }
 
@@ -620,71 +650,85 @@ async fn refresh_task<
     loop {
         // Determine if the token needs to be refreshed
         let now = Instant::now();
-        let client_id = inner.oauth2_client.client_id().as_str();
 
-        let span = tracing::span!(tracing::Level::TRACE, "refresh_task", client_id = client_id);
-        let _enter = span.enter();
+        let span = tracing::span!(
+            tracing::Level::TRACE,
+            "refresh_task",
+            client_id = inner.oauth2_client.client_id().as_str()
+        );
 
-        let sleep_duration = {
+        // Decide how long to sleep before the next refresh. Returns `None` when the
+        // token never expires and the refresh loop should stop entirely.
+        // The lock is only held inside this synchronous closure, never across an
+        // `.await` (see issue #11).
+        let sleep_duration = span.in_scope(|| -> Option<Duration> {
             let state_read_guard = inner.token.read().expect("Non-poisoned lock");
-            let token = (*state_read_guard).clone();
-            drop(state_read_guard);
 
-            if let Ok(token) = token {
-                if let Some(expiry) = token.token_expiry {
-                    let expires_in = if expiry > now {
-                        expiry - now
-                    } else {
-                        Duration::from_secs(0)
-                    };
-
-                    // Token expires in less than TOLERANCE seconds -> Process now
-                    if expires_in < inner.tolerance {
-                        tracing::warn!(
-                            "Token expires in {}s which is less than the minimum allowed refresh interval of {}s. Refreshing in {}s.",
-                            expires_in.as_secs(),
-                            inner.tolerance.as_secs(),
-                            inner.tolerance.as_secs()
-                        );
-                        Duration::from_secs(inner.tolerance.as_secs())
-                    } else {
-                        let next_refresh = expires_in.checked_sub(inner.tolerance).unwrap_or_else(|| {
-                            tracing::error!(
-                                "Failed to calculate next refresh time: expires_in ({:?}) < tolerance ({:?}). This should not happen. Refreshing immediately.",
-                                expires_in,
-                                inner.tolerance
-                            );
-                            Duration::from_secs(0)
-                        });
-                        // Token expires in more than Tolerance seconds -> Sleep until Tolerance seconds before expiry
-                        tracing::trace!(
-                            "Token expires in {}s. Refreshing in {}s.",
-                            expires_in.as_secs(),
-                            next_refresh.as_secs()
-                        );
-                        next_refresh
-                    }
-                } else {
-                    // Token does not expire. We don't need a background task
-                    tracing::debug!("Token does not expire. Disabling refresh task.",);
-                    return;
-                }
-            } else {
+            // No valid token cached (a previous refresh failed and the old token
+            // has expired): retry after `tolerance`.
+            let Ok(token) = &*state_read_guard else {
+                // Floor the retry delay so a small/zero `tolerance` can't turn a
+                // sustained outage into a tight loop against the IdP.
+                let retry_in = inner.tolerance.max(MIN_REFRESH_INTERVAL);
                 tracing::trace!(
-                    "Failed to refresh token. Retrying in {}s",
-                    inner.tolerance.as_secs()
+                    "No valid token available. Retrying in {}s",
+                    retry_in.as_secs()
                 );
-                Duration::from_secs(inner.tolerance.as_secs())
+                return Some(retry_in);
+            };
+
+            // Token never expires: stop the refresh loop entirely.
+            let Some(expiry) = token.token_expiry else {
+                tracing::debug!("Token does not expire. Disabling refresh task.");
+                return None;
+            };
+
+            let expires_in = expiry.saturating_duration_since(now);
+            if expires_in < inner.tolerance {
+                // The token already lives for less than `tolerance`, so we cannot
+                // honour the full tolerance. Refresh roughly halfway through the
+                // remaining lifetime (never below `MIN_REFRESH_INTERVAL`) so the
+                // token is renewed before it expires without busy-looping the IdP.
+                let next_refresh = (expires_in / 2).max(MIN_REFRESH_INTERVAL);
+                tracing::debug!(
+                    "Token lifetime ({}s) is shorter than the refresh tolerance ({}s). Refreshing in {}s.",
+                    expires_in.as_secs(),
+                    inner.tolerance.as_secs(),
+                    next_refresh.as_secs()
+                );
+                Some(next_refresh)
+            } else {
+                // Refresh `tolerance` before expiry, but never below the floor so a
+                // token whose lifetime only barely exceeds `tolerance` can't spin
+                // the loop against the IdP.
+                let next_refresh = expires_in
+                    .saturating_sub(inner.tolerance)
+                    .max(MIN_REFRESH_INTERVAL);
+                tracing::trace!(
+                    "Token expires in {}s. Refreshing in {}s.",
+                    expires_in.as_secs(),
+                    next_refresh.as_secs()
+                );
+                Some(next_refresh)
             }
+        });
+
+        let Some(sleep_duration) = sleep_duration else {
+            return;
         };
 
-        tracing::trace!("Sleeping for {}s", sleep_duration.as_secs());
-        #[cfg(feature = "runtime-tokio")]
-        tokio::time::sleep(sleep_duration).await;
-
         // `refresh_token` already records the result, including failures.
-        tracing::trace!("Refreshing token for client `{}`", client_id);
-        let _tr = inner.refresh_token().await.ok();
+        // Instrument the async work with the span instead of holding an `enter`
+        // guard across the `.await` points.
+        async {
+            tracing::trace!("Sleeping for {}s", sleep_duration.as_secs());
+            #[cfg(feature = "runtime-tokio")]
+            tokio::time::sleep(sleep_duration).await;
+            tracing::trace!("Refreshing token");
+            inner.refresh_token().await.ok();
+        }
+        .instrument(span)
+        .await;
     }
 }
 
@@ -789,18 +833,29 @@ impl<
         .await;
 
         // Unwrap RWLock to propagate poison (writer panicked)
-        // Get write lock immediately to not spawn multiple token fetch threads
         let mut state_write_guard = self.token.write().expect("Non-poisoned lock");
 
-        let token = tr
-            .as_ref()
-            .map_err(|e| {
+        match tr.as_ref() {
+            Ok(tr) => {
+                // Successful refresh: store the new token (or a conversion error if
+                // the access token is not a valid header value).
+                *state_write_guard = Token::try_from_tr(tr);
+            }
+            Err(e) => {
                 tracing::error!("Failed to refresh token: {e}");
-                e.clone()
-            })
-            .and_then(Token::try_from_tr);
+                // Keep serving the currently cached token while it is still valid;
+                // only surface the refresh error once we no longer have a usable
+                // token. This prevents a transient IdP outage during the refresh
+                // window (which fires `tolerance` before expiry) from discarding an
+                // otherwise-valid token.
+                let keep_existing =
+                    matches!(&*state_write_guard, Ok(token) if !token.is_expired());
+                if !keep_existing {
+                    *state_write_guard = Err(e.clone());
+                }
+            }
+        }
 
-        *state_write_guard = token;
         drop(state_write_guard);
         tr
     }
@@ -833,13 +888,33 @@ impl<
         // Unwrap RWLock to propagate poison (writer panicked)
         let state_read_guard = self.inner.token.read().expect("Non-poisoned lock");
 
-        let token = state_read_guard
-            .as_ref()
-            .map(|t| t.token.clone())
-            .map_err(Clone::clone);
+        match &*state_read_guard {
+            // A cached token that has outlived its expiry (a refresh has been
+            // failing) must not be handed out, even though we keep it around so
+            // the refresh task can decide when to give up.
+            Ok(token) if token.is_expired() => Err(Error::TokenExpired),
+            Ok(token) => Ok(token.token.clone()),
+            Err(e) => Err(e.clone()),
+        }
+    }
 
-        drop(state_read_guard);
-        token
+    #[cfg(feature = "tonic")]
+    fn authorization_header_tonic(
+        &self,
+    ) -> std::result::Result<
+        tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+        tonic::Status,
+    > {
+        // Clone the pre-computed metadata value (cheap, `Bytes`-backed) instead of
+        // re-parsing the header string on every request.
+        let state_read_guard = self.inner.token.read().expect("Non-poisoned lock");
+        match &*state_read_guard {
+            Ok(token) if token.is_expired() => Err(tonic::Status::unauthenticated(
+                Error::TokenExpired.to_string(),
+            )),
+            Ok(token) => Ok(token.metadata.clone()),
+            Err(e) => Err(tonic::Status::unauthenticated(e.to_string())),
+        }
     }
 }
 
@@ -1071,5 +1146,216 @@ mod test {
 
         let header = authorizer.authorization_header().unwrap();
         assert_eq!(header.to_str().unwrap(), "Bearer my-issued-token");
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_refresh_failure_keeps_valid_token() {
+        let mut oauth_server = mockito::Server::new_async().await;
+        let url = oauth_server.url();
+        // Initial fetch succeeds with a long-lived token. Refresh is disabled so
+        // the background task cannot race with the manual refresh below.
+        let success = oauth_server
+            .mock("POST", "/token")
+            .with_status(200)
+            .with_header(CONTENT_TYPE.as_str(), "application/json")
+            .with_body(
+                serde_json::json!({
+                    "access_token": "first-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let authorizer = BasicClientCredentialAuthorizerBuilder::new(
+            "my-client",
+            "my-secret",
+            format!("{url}/token").parse().unwrap(),
+        )
+        .disable_refresh()
+        .build()
+        .await
+        .unwrap();
+
+        success.assert_async().await;
+        assert_eq!(
+            authorizer.authorization_header().unwrap().to_str().unwrap(),
+            "Bearer first-token"
+        );
+
+        // The IdP now fails for every token request.
+        let failure = oauth_server
+            .mock("POST", "/token")
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        // A failed refresh must NOT discard the still-valid cached token.
+        let result = authorizer.inner.refresh_token().await;
+        assert!(result.is_err(), "refresh should report the failure");
+        failure.assert_async().await;
+        assert_eq!(
+            authorizer.authorization_header().unwrap().to_str().unwrap(),
+            "Bearer first-token",
+            "a still-valid token must be retained when refresh fails"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_refresh_failure_surfaces_error_once_token_expired() {
+        let mut oauth_server = mockito::Server::new_async().await;
+        let url = oauth_server.url();
+        let success = oauth_server
+            .mock("POST", "/token")
+            .with_status(200)
+            .with_header(CONTENT_TYPE.as_str(), "application/json")
+            .with_body(
+                serde_json::json!({
+                    "access_token": "first-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let authorizer = BasicClientCredentialAuthorizerBuilder::new(
+            "my-client",
+            "my-secret",
+            format!("{url}/token").parse().unwrap(),
+        )
+        .disable_refresh()
+        .build()
+        .await
+        .unwrap();
+        success.assert_async().await;
+
+        // Force the cached token to be already expired.
+        {
+            let mut guard = authorizer.inner.token.write().unwrap();
+            if let Ok(token) = guard.as_mut() {
+                token.token_expiry = Some(
+                    Instant::now()
+                        .checked_sub(Duration::from_secs(1))
+                        .expect("monotonic clock is at least 1s past its epoch"),
+                );
+            }
+        }
+
+        let _failure = oauth_server
+            .mock("POST", "/token")
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        // With no usable token left, the refresh error must be surfaced.
+        let result = authorizer.inner.refresh_token().await;
+        assert!(result.is_err());
+        assert!(
+            authorizer.authorization_header().is_err(),
+            "an expired token must not be served after a failed refresh"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_expired_token_not_served_on_read() {
+        let mut oauth_server = mockito::Server::new_async().await;
+        let url = oauth_server.url();
+        let success = oauth_server
+            .mock("POST", "/token")
+            .with_status(200)
+            .with_header(CONTENT_TYPE.as_str(), "application/json")
+            .with_body(
+                serde_json::json!({
+                    "access_token": "first-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let authorizer = BasicClientCredentialAuthorizerBuilder::new(
+            "my-client",
+            "my-secret",
+            format!("{url}/token").parse().unwrap(),
+        )
+        .disable_refresh()
+        .build()
+        .await
+        .unwrap();
+        success.assert_async().await;
+        assert!(authorizer.authorization_header().is_ok());
+
+        // Force-expire the cached token. The read path must reject it without any
+        // refresh having run.
+        {
+            let mut guard = authorizer.inner.token.write().unwrap();
+            if let Ok(token) = guard.as_mut() {
+                token.token_expiry = Some(
+                    Instant::now()
+                        .checked_sub(Duration::from_secs(1))
+                        .expect("monotonic clock is at least 1s past its epoch"),
+                );
+            }
+        }
+
+        assert!(matches!(
+            authorizer.authorization_header(),
+            Err(Error::TokenExpired)
+        ));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_short_lived_token_refreshes_before_expiry() {
+        let mut oauth_server = mockito::Server::new_async().await;
+        let url = oauth_server.url();
+        // Token lifetime (2s) is shorter than the refresh tolerance (10s), so the
+        // loop must take the "refresh partway through remaining life" branch and
+        // keep renewing (~1s cadence) instead of sleeping the full tolerance. With
+        // the old behaviour it would sleep ~10s and only the initial fetch would
+        // happen within the window below.
+        let mock = oauth_server
+            .mock("POST", "/token")
+            .with_status(200)
+            .with_header(CONTENT_TYPE.as_str(), "application/json")
+            .with_body(
+                serde_json::json!({
+                    "access_token": "tok",
+                    "token_type": "bearer",
+                    "expires_in": 2
+                })
+                .to_string(),
+            )
+            .expect_at_least(2)
+            .create_async()
+            .await;
+
+        let authorizer = BasicClientCredentialAuthorizerBuilder::new(
+            "my-client",
+            "my-secret",
+            format!("{url}/token").parse().unwrap(),
+        )
+        .refresh_tolerance(Duration::from_secs(10))
+        .build()
+        .await
+        .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(2500)).await;
+        mock.assert_async().await;
+        assert!(authorizer.authorization_header().is_ok());
     }
 }

--- a/crates/middle/src/client.rs
+++ b/crates/middle/src/client.rs
@@ -134,15 +134,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_http_client() {
+        // Use a local mock server so the test is deterministic and offline. It
+        // also verifies the authorizer actually attaches the bearer header.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/get")
+            .match_header("authorization", "Bearer test")
+            .with_status(200)
+            .create_async()
+            .await;
+
         let authorizer = BearerTokenAuthorizer::new("test").unwrap();
         let client = HttpClient::new(authorizer);
 
         let response = client
-            .get("https://httpbin.org/get")
+            .get(format!("{}/get", server.url()))
             .unwrap()
             .send()
             .await
             .unwrap();
+
+        mock.assert_async().await;
         assert!(response.status().is_success());
     }
 }

--- a/crates/middle/src/error.rs
+++ b/crates/middle/src/error.rs
@@ -12,16 +12,6 @@ pub enum Error {
     OAuth2ParseError(String),
     #[error("Request failed: {0}")]
     ReqwestFailed(#[from] Arc<reqwest::Error>),
-}
-
-impl Error {
-    // pub fn internal(
-    //     reason: impl Into<String>,
-    //     error: impl Into<Box<dyn std::error::Error + Send + Sync>>,
-    // ) -> Self {
-    //     Self::InternalError {
-    //         reason: reason.into(),
-    //         source: error.into(),
-    //     }
-    // }
+    #[error("Token has expired and a refresh has not yet succeeded.")]
+    TokenExpired,
 }


### PR DESCRIPTION
Reliability fixes to the client-credentials authorizer plus a hot-path allocation removal:

- Retain a still-valid token when a background refresh fails. Previously a transient IdP error during the refresh window (which fires `tolerance` before expiry) overwrote the cached token with the error, failing every request until the next retry despite a usable token in hand.
- Reject expired tokens on read: authorization_header[_tonic]() now return Error::TokenExpired instead of serving a token that has outlived its expiry while refreshes keep failing.
- Stop holding the tracing span enter() guard across .await in the refresh loop (#11): use span.in_scope() for the sync decision and .instrument(span) for the async work.
- Refresh short-lived tokens (lifetime < tolerance) partway through their remaining life instead of sleeping the full tolerance, and floor every refresh delay at MIN_REFRESH_INTERVAL (1s) so a small/zero tolerance or a lifetime ~= tolerance can't spin the loop against the IdP.
- Pre-compute the tonic MetadataValue once per token and clone it on the interceptor hot path instead of re-parsing the header on every request; mark it sensitive for HPACK never-indexing (behind the `tonic` feature).
- Remove dead commented-out code in error.rs.

Adds regression tests for token retention, expired-token rejection, and the short-lived-token refresh cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client credential refresh so valid cached tokens remain usable during temporary refresh failures.
  * Added a clearer error when cached tokens are expired and refresh hasn’t yet succeeded, preventing expired tokens from being used.
  * Improved refresh timing to avoid tight retry loops and refresh short-lived tokens ahead of expiry.
  * Enhanced authentication for gRPC requests by reusing precomputed authorization metadata when supported.
* **Tests**
  * Made the HTTP client test deterministic and offline.
  * Added async coverage for refresh failure handling, expiration rejection, and refresh timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->