### PR TITLE
chore(deps): bump mockito dev-dependency floor to 1.7

### DIFF
--- a/crates/middle/Cargo.toml
+++ b/crates/middle/Cargo.toml
@@ -34,7 +34,7 @@ url = { workspace = true, features = ["serde"] }
 veil = "0.3"
 
 [dev-dependencies]
-mockito = "1.6.1"
+mockito = "1.7"
 pretty_assertions = "1.4"
 serde_json = "1.0"
 tokio = { version = "1.43", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Raise the mockito minimum from 1.6.1 to 1.7 (latest 1.7.2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to a newer version for improved test tooling and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->