### PR TITLE
refactor(authorizers): extract shared bearer-header builder

### DIFF
--- a/crates/middle/src/authorizers/bearer_token.rs
+++ b/crates/middle/src/authorizers/bearer_token.rs
@@ -5,8 +5,8 @@ use http::HeaderValue;
 #[cfg(feature = "tonic")]
 use tonic::service::Interceptor;
 
-use super::{Authorizer, require_ascii};
-use crate::error::{Error, Result};
+use super::{Authorizer, bearer_header, require_ascii};
+use crate::error::Result;
 
 /// Create a simple Authorizer that attaches a given token to any request
 /// a client sends. The token is attached with the `Bearer` auth-scheme.
@@ -34,24 +34,11 @@ impl BearerTokenAuthorizer {
     /// Fails if "Bearer {token}" is not a valid ASCII string.
     pub fn new(token: &str) -> Result<Self> {
         require_ascii(token)?;
-        let bearer = format!("Bearer {token}");
-        let mut authentication_header =
-            HeaderValue::from_str(&bearer).map_err(|_e| Error::InvalidHeaderValue)?;
-        authentication_header.set_sensitive(true);
-
-        #[cfg(feature = "tonic")]
-        let authorization_metadata = {
-            use std::str::FromStr;
-            let mut metadata = tonic::metadata::MetadataValue::from_str(&bearer)
-                .map_err(|_e| Error::InvalidHeaderValue)?;
-            metadata.set_sensitive(true);
-            metadata
-        };
-
+        let built = bearer_header(token)?;
         Ok(Self {
-            authorization_header: Arc::new(authentication_header),
+            authorization_header: built.header,
             #[cfg(feature = "tonic")]
-            authorization_metadata,
+            authorization_metadata: built.metadata,
         })
     }
 }

--- a/crates/middle/src/authorizers/client_credentials.rs
+++ b/crates/middle/src/authorizers/client_credentials.rs
@@ -270,23 +270,11 @@ struct Token {
 
 impl Token {
     fn try_from_tr<TR: TokenResponse>(tr: &TR) -> Result<Self, Error> {
-        let bearer = format!("Bearer {}", tr.access_token().secret());
-        let mut token = HeaderValue::from_str(&bearer).map_err(|_| Error::InvalidHeaderValue)?;
-        token.set_sensitive(true);
-
-        #[cfg(feature = "tonic")]
-        let metadata = {
-            use std::str::FromStr;
-            let mut metadata = tonic::metadata::MetadataValue::from_str(&bearer)
-                .map_err(|_| Error::InvalidHeaderValue)?;
-            metadata.set_sensitive(true);
-            metadata
-        };
-
+        let built = super::bearer_header(tr.access_token().secret())?;
         Ok(Token {
-            token: Arc::new(token),
+            token: built.header,
             #[cfg(feature = "tonic")]
-            metadata,
+            metadata: built.metadata,
             token_expiry: tr.expires_in().map(|e| Instant::now() + e),
         })
     }

--- a/crates/middle/src/authorizers/mod.rs
+++ b/crates/middle/src/authorizers/mod.rs
@@ -58,3 +58,41 @@ pub(crate) fn require_ascii(s: &str) -> Result<(), crate::error::Error> {
         Err(crate::error::Error::InvalidHeaderValue)
     }
 }
+
+/// Pre-computed representations of an `Authorization: Bearer <token>` header,
+/// shared by the authorizers so the [`HeaderValue`] and (with the `tonic`
+/// feature) the `MetadataValue` are always built and marked sensitive the same
+/// way.
+pub(crate) struct BearerHeader {
+    pub(crate) header: Arc<HeaderValue>,
+    #[cfg(feature = "tonic")]
+    pub(crate) metadata: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+}
+
+/// Build the sensitive `Authorization: Bearer <token>` representations from a raw
+/// token (passed without the `Bearer ` prefix).
+///
+/// # Errors
+/// Fails with `InvalidHeaderValue` if the resulting header value is invalid
+/// (for example non-ASCII).
+pub(crate) fn bearer_header(token: &str) -> Result<BearerHeader, crate::error::Error> {
+    let bearer = format!("Bearer {token}");
+    let mut header =
+        HeaderValue::from_str(&bearer).map_err(|_| crate::error::Error::InvalidHeaderValue)?;
+    header.set_sensitive(true);
+
+    #[cfg(feature = "tonic")]
+    let metadata = {
+        use std::str::FromStr;
+        let mut metadata = tonic::metadata::MetadataValue::from_str(&bearer)
+            .map_err(|_| crate::error::Error::InvalidHeaderValue)?;
+        metadata.set_sensitive(true);
+        metadata
+    };
+
+    Ok(BearerHeader {
+        header: Arc::new(header),
+        #[cfg(feature = "tonic")]
+        metadata,
+    })
+}


### PR DESCRIPTION
Deduplicate the "format Bearer value, parse HeaderValue/MetadataValue, mark sensitive" logic that was copied in BearerTokenAuthorizer::new and Token::try_from_tr into a single bearer_header() helper, so both the header and (tonic) metadata representations are always built consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how bearer authentication details are built and reused, making token handling more consistent across requests.
  * Reduced the chance of malformed authorization values by standardizing header creation and validation.
  * Better support for gRPC-related authentication metadata when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->